### PR TITLE
feat: theme rework

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,8 +12,12 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Hive.initFlutter();
 
-  runApp(ChangeNotifierProvider<ThemeModel>(
-      create: (_) => ThemeModel(), child: const MyApp()));
+  runApp(
+    ChangeNotifierProvider<ThemeModel>(
+      create: (_) => ThemeModel(),
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
@@ -21,7 +25,15 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(home: MyHome());
+    return ChangeNotifierProvider(
+      create: (context) => AppStateHandler(),
+      child: MaterialApp(
+        theme: lightTheme,
+        darkTheme: darkTheme,
+        themeMode: Provider.of<ThemeModel>(context).currentMode,
+        home: const MyHome(),
+      ),
+    );
   }
 }
 
@@ -62,32 +74,26 @@ class _MyHomeState extends State<MyHome> with WidgetsBindingObserver {
   Widget build(BuildContext context) {
     const navigationHomeScreen = NavigationHomeScreen();
 
-    return ChangeNotifierProvider(
-      create: (context) => appState,
-      child: MaterialApp(
-        theme: Provider.of<ThemeModel>(context).currentTheme,
-        home: Scaffold(
-          body: Consumer<AppStateHandler>(
-            child: navigationHomeScreen,
-            builder: (context, stateHandler, child) {
-              debugPrint('AppState: ${appState.currentState}');
-              Fluttertoast.showToast(
-                msg: 'AppState: ${appState.currentState.name}',
-                toastLength: Toast.LENGTH_LONG,
-                gravity: ToastGravity.BOTTOM,
-              );
-              if (appState.currentState == AppState.loggedOut) {
-                return const LoginScreen();
-              } else if (appState.currentState == AppState.loadData ||
-                  appState.currentState == AppState.resume) {
-                return const CircularProgressIndicator();
-              } else if (appState.currentState == AppState.authenticated) {
-                return const NavigationHomeScreen();
-              }
-              return child!;
-            },
-          ),
-        ),
+    return Scaffold(
+      body: Consumer<AppStateHandler>(
+        child: navigationHomeScreen,
+        builder: (context, stateHandler, child) {
+          debugPrint('AppState: ${appState.currentState}');
+          Fluttertoast.showToast(
+            msg: 'AppState: ${appState.currentState.name}',
+            toastLength: Toast.LENGTH_LONG,
+            gravity: ToastGravity.BOTTOM,
+          );
+          if (appState.currentState == AppState.loggedOut) {
+            return const LoginScreen();
+          } else if (appState.currentState == AppState.loadData ||
+              appState.currentState == AppState.resume) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (appState.currentState == AppState.authenticated) {
+            return const NavigationHomeScreen();
+          }
+          return child!;
+        },
       ),
     );
   }

--- a/lib/screens/mitgliedsliste/mitglied_liste.dart
+++ b/lib/screens/mitgliedsliste/mitglied_liste.dart
@@ -6,6 +6,7 @@ import 'package:nami/screens/mitgliedsliste/mitglied_details.dart';
 import 'package:nami/utilities/hive/mitglied.dart';
 import 'package:nami/utilities/mitglied.filterAndSort.dart';
 import 'package:nami/utilities/stufe.dart';
+import 'package:nami/utilities/theme.dart';
 
 import 'mitglied_bearbeiten.dart';
 
@@ -128,7 +129,7 @@ class MitgliedsListeState extends State<MitgliedsListe> {
                         gradient: LinearGradient(
                             colors: [
                               filteredMitglieder[index].isMitgliedLeiter()
-                                  ? Stufe.leiterFarbe
+                                  ? DPSGColors.leiterFarbe
                                   : Stufe.getStufeByString(
                                           filteredMitglieder[index].stufe)
                                       .farbe,
@@ -200,7 +201,9 @@ class MitgliedsListeState extends State<MitgliedsListe> {
               height: 50.0,
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
-                color: filterGroup[index] ? Colors.blue : Colors.grey,
+                color: filterGroup[index]
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).colorScheme.surfaceVariant,
               ),
               child: Center(
                 child: Image.asset(

--- a/lib/screens/widgets/groupBarChart.widget.dart
+++ b/lib/screens/widgets/groupBarChart.widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:nami/utilities/hive/mitglied.dart';
+import 'package:nami/utilities/theme.dart';
 
 class GroupBarChart extends StatefulWidget {
   final List<Mitglied> mitglieder;
@@ -63,24 +64,54 @@ class GroupBarChartState extends State<GroupBarChart> {
     getMemberPerGroup().forEach((key, value) {
       switch (key) {
         case "Wölfling":
-          sectionData.add(createGroupData(index, value.leiter.toDouble(),
-              value.mitglied.toDouble(), Colors.orange));
+          sectionData.add(
+            createGroupData(
+              index,
+              value.leiter.toDouble(),
+              value.mitglied.toDouble(),
+              DPSGColors.woelfingFarbe,
+            ),
+          );
           break;
         case "Jungpfadfinder":
-          sectionData.add(createGroupData(index, value.leiter.toDouble(),
-              value.mitglied.toDouble(), Colors.blue));
+          sectionData.add(
+            createGroupData(
+              index,
+              value.leiter.toDouble(),
+              value.mitglied.toDouble(),
+              DPSGColors.jungpfadfinderFarbe,
+            ),
+          );
           break;
         case "Pfadfinder":
-          sectionData.add(createGroupData(index, value.leiter.toDouble(),
-              value.mitglied.toDouble(), Colors.green));
+          sectionData.add(
+            createGroupData(
+              index,
+              value.leiter.toDouble(),
+              value.mitglied.toDouble(),
+              DPSGColors.pfadfinderFarbe,
+            ),
+          );
           break;
         case "Rover":
-          sectionData.add(createGroupData(index, value.leiter.toDouble(),
-              value.mitglied.toDouble(), Colors.red));
+          sectionData.add(
+            createGroupData(
+              index,
+              value.leiter.toDouble(),
+              value.mitglied.toDouble(),
+              DPSGColors.roverFarbe,
+            ),
+          );
           break;
         default:
-          sectionData.add(createGroupData(index, value.leiter.toDouble(),
-              value.mitglied.toDouble(), Colors.grey));
+          sectionData.add(
+            createGroupData(
+              index,
+              value.leiter.toDouble(),
+              value.mitglied.toDouble(),
+              DPSGColors.leiterFarbe,
+            ),
+          );
           break;
       }
       index++;
@@ -148,6 +179,7 @@ class GroupBarChartState extends State<GroupBarChart> {
 
   @override
   Widget build(BuildContext context) {
+    final data = createData();
     return AspectRatio(
       aspectRatio: 1.3,
       child: BarChart(
@@ -167,8 +199,11 @@ class GroupBarChartState extends State<GroupBarChart> {
               ) {
                 return BarTooltipItem(
                   rod.toY > 0 ? (rod.toY - rod.fromY).round().toString() : '',
-                  const TextStyle(
-                    color: Colors.black,
+                  TextStyle(
+                    color: rod.toY >=
+                            1 // Color text on bar different that on surface
+                        ? Colors.black
+                        : Theme.of(context).colorScheme.onBackground,
                   ),
                 );
               },
@@ -188,7 +223,7 @@ class GroupBarChartState extends State<GroupBarChart> {
           ),
           borderData: FlBorderData(show: false),
           gridData: const FlGridData(show: false),
-          barGroups: createData(),
+          barGroups: data,
           maxY: findHighestValue(getMemberPerGroup()).toDouble() + 5,
         ),
       ),

--- a/lib/utilities/custom_drawer/home_drawer.dart
+++ b/lib/utilities/custom_drawer/home_drawer.dart
@@ -155,103 +155,99 @@ class HomeDrawerState extends State<HomeDrawer> {
   }
 
   Widget inkwell(DrawerList listData) {
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        splashColor: Colors.grey.withOpacity(0.1),
-        highlightColor: Colors.transparent,
-        onTap: () {
-          navigationtoScreen(listData.index!);
-        },
-        child: Stack(
-          children: <Widget>[
-            Container(
-              padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: Row(
-                children: <Widget>[
-                  const SizedBox(
-                    width: 6.0,
-                    height: 46.0,
-                    // decoration: BoxDecoration(
-                    //   color: widget.screenIndex == listData.index
-                    //       ? Colors.blue
-                    //       : Colors.transparent,
-                    //   borderRadius: new BorderRadius.only(
-                    //     topLeft: Radius.circular(0),
-                    //     topRight: Radius.circular(16),
-                    //     bottomLeft: Radius.circular(0),
-                    //     bottomRight: Radius.circular(16),
-                    //   ),
-                    // ),
+    final itemColor = widget.screenIndex == listData.index
+        ? Theme.of(context).colorScheme.onPrimaryContainer
+        : Theme.of(context).colorScheme.onBackground;
+
+    return InkWell(
+      splashColor: Colors.grey.withOpacity(0.1),
+      highlightColor: Colors.transparent,
+      onTap: () {
+        navigationtoScreen(listData.index!);
+      },
+      child: Stack(
+        children: <Widget>[
+          Container(
+            padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
+            child: Row(
+              children: <Widget>[
+                const SizedBox(
+                  width: 6.0,
+                  height: 46.0,
+                  // decoration: BoxDecoration(
+                  //   color: widget.screenIndex == listData.index
+                  //       ? Colors.blue
+                  //       : Colors.transparent,
+                  //   borderRadius: new BorderRadius.only(
+                  //     topLeft: Radius.circular(0),
+                  //     topRight: Radius.circular(16),
+                  //     bottomLeft: Radius.circular(0),
+                  //     bottomRight: Radius.circular(16),
+                  //   ),
+                  // ),
+                ),
+                const Padding(
+                  padding: EdgeInsets.all(4.0),
+                ),
+                listData.isAssetsImage
+                    ? SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: Image.asset(
+                          listData.imageName,
+                          color: itemColor,
+                        ),
+                      )
+                    : Icon(
+                        listData.icon?.icon,
+                        color: itemColor,
+                      ),
+                const Padding(padding: EdgeInsets.all(4.0)),
+                Text(
+                  listData.labelName,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w500,
+                    fontSize: 16,
+                    color: itemColor,
                   ),
-                  const Padding(
-                    padding: EdgeInsets.all(4.0),
-                  ),
-                  listData.isAssetsImage
-                      ? SizedBox(
-                          width: 24,
-                          height: 24,
-                          child: Image.asset(listData.imageName,
-                              color: widget.screenIndex == listData.index
-                                  ? Colors.blue
-                                  : Theme.of(context).primaryColor),
-                        )
-                      : Icon(listData.icon?.icon,
-                          color: widget.screenIndex == listData.index
-                              ? Colors.blue
-                              : Theme.of(context).primaryColor),
-                  const Padding(
-                    padding: EdgeInsets.all(4.0),
-                  ),
-                  Text(
-                    listData.labelName,
-                    style: TextStyle(
-                      fontWeight: FontWeight.w500,
-                      fontSize: 16,
-                      color: widget.screenIndex == listData.index
-                          ? Colors.blue
-                          : Theme.of(context).primaryColor,
-                    ),
-                    textAlign: TextAlign.left,
-                  ),
-                ],
-              ),
+                  textAlign: TextAlign.left,
+                ),
+              ],
             ),
-            widget.screenIndex == listData.index
-                ? AnimatedBuilder(
-                    animation: widget.iconAnimationController!,
-                    builder: (BuildContext context, Widget? child) {
-                      return Transform(
-                        transform: Matrix4.translationValues(
-                            (MediaQuery.of(context).size.width * 0.75 - 64) *
-                                (1.0 -
-                                    widget.iconAnimationController!.value -
-                                    1.0),
-                            0.0,
-                            0.0),
-                        child: Padding(
-                          padding: const EdgeInsets.only(top: 8, bottom: 8),
-                          child: Container(
-                            width:
-                                MediaQuery.of(context).size.width * 0.75 - 64,
-                            height: 46,
-                            decoration: BoxDecoration(
-                              color: Colors.blue.withOpacity(0.2),
-                              borderRadius: const BorderRadius.only(
-                                topLeft: Radius.circular(0),
-                                topRight: Radius.circular(28),
-                                bottomLeft: Radius.circular(0),
-                                bottomRight: Radius.circular(28),
-                              ),
+          ),
+          widget.screenIndex == listData.index
+              ? AnimatedBuilder(
+                  animation: widget.iconAnimationController!,
+                  builder: (BuildContext context, Widget? child) {
+                    return Transform(
+                      transform: Matrix4.translationValues(
+                          (MediaQuery.of(context).size.width * 0.75 - 64) *
+                              (1.0 -
+                                  widget.iconAnimationController!.value -
+                                  1.0),
+                          0.0,
+                          0.0),
+                      child: Padding(
+                        padding: const EdgeInsets.only(top: 8, bottom: 8),
+                        child: Container(
+                          width: MediaQuery.of(context).size.width * 0.75 - 64,
+                          height: 46,
+                          decoration: BoxDecoration(
+                            color: Colors.blue.withOpacity(0.2),
+                            borderRadius: const BorderRadius.only(
+                              topLeft: Radius.circular(0),
+                              topRight: Radius.circular(28),
+                              bottomLeft: Radius.circular(0),
+                              bottomRight: Radius.circular(28),
                             ),
                           ),
                         ),
-                      );
-                    },
-                  )
-                : const SizedBox()
-          ],
-        ),
+                      ),
+                    );
+                  },
+                )
+              : const SizedBox()
+        ],
       ),
     );
   }

--- a/lib/utilities/stufe.dart
+++ b/lib/utilities/stufe.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: constant_identifier_names
 
 import 'package:flutter/material.dart';
+import 'package:nami/utilities/theme.dart';
 
 enum StufeEnum {
   BIBER,
@@ -44,19 +45,11 @@ class Stufe implements Comparable<Stufe> {
   final int? alterMax;
   final String? imageName;
 
-  static const biberFarbe = Color(0xFFFFFFFF);
-  static const woelfingFarbe = Color(0xFFf56403);
-  static const jungpfadfinderFarbe = Color(0xFF007bff);
-  static const pfadfinderFarbe = Color(0xFF26823c);
-  static const roverFarbe = Color(0xFFdc3545);
-  static const leiterFarbe = Color(0xFF949494);
-  static const keineStufeFarbe = Color(0xFF949494);
-
   static final List<Stufe> stufen = [
     Stufe(
       StufeEnum.BIBER,
       0,
-      woelfingFarbe,
+      DPSGColors.biberFarbe,
       isStufeYouCanChangeTo: true,
       alterMin: 4,
       alterMax: 10,
@@ -65,7 +58,7 @@ class Stufe implements Comparable<Stufe> {
     Stufe(
       StufeEnum.WOELFLING,
       1,
-      woelfingFarbe,
+      DPSGColors.woelfingFarbe,
       isStufeYouCanChangeTo: true,
       alterMin: 6,
       alterMax: 10,
@@ -74,7 +67,7 @@ class Stufe implements Comparable<Stufe> {
     Stufe(
       StufeEnum.JUNGPADFINDER,
       2,
-      jungpfadfinderFarbe,
+      DPSGColors.jungpfadfinderFarbe,
       isStufeYouCanChangeTo: true,
       alterMin: 9,
       alterMax: 13,
@@ -83,7 +76,7 @@ class Stufe implements Comparable<Stufe> {
     Stufe(
       StufeEnum.PFADFINDER,
       3,
-      pfadfinderFarbe,
+      DPSGColors.pfadfinderFarbe,
       isStufeYouCanChangeTo: true,
       alterMin: 12,
       alterMax: 16,
@@ -92,7 +85,7 @@ class Stufe implements Comparable<Stufe> {
     Stufe(
       StufeEnum.ROVER,
       4,
-      roverFarbe,
+      DPSGColors.roverFarbe,
       isStufeYouCanChangeTo: true,
       alterMin: 15,
       alterMax: 20,
@@ -101,12 +94,12 @@ class Stufe implements Comparable<Stufe> {
     Stufe(
       StufeEnum.LEITER,
       5,
-      leiterFarbe,
+      DPSGColors.leiterFarbe,
       isStufeYouCanChangeTo: false,
       alterMin: 18,
       imageName: 'leiter.png',
     ),
-    Stufe(StufeEnum.KEINE_STUFE, 7, keineStufeFarbe),
+    Stufe(StufeEnum.KEINE_STUFE, 7, DPSGColors.keineStufeFarbe),
   ];
 
   static Stufe? getStufeByOrder(int order) {

--- a/lib/utilities/theme.dart
+++ b/lib/utilities/theme.dart
@@ -33,7 +33,7 @@ final lightTheme = ThemeData(
 );
 
 class ThemeModel extends ChangeNotifier {
-  ThemeMode currentMode = ThemeMode.light;
+  ThemeMode currentMode = ThemeMode.system;
 
   setTheme(ThemeMode type) {
     currentMode = type;

--- a/lib/utilities/theme.dart
+++ b/lib/utilities/theme.dart
@@ -2,78 +2,41 @@ import 'package:flutter/material.dart';
 
 const Color darkSecondary = Color(0xFF520081);
 
+abstract class DPSGColors {
+  static const primary = Color(0xFF003056);
+  static const secondary = Color(0xFF810a1a);
+  static const biberFarbe = Color(0xFFFFFFFF);
+  static const woelfingFarbe = Color(0xFFFF6400);
+  static const jungpfadfinderFarbe = Color(0xFF2f53a7);
+  static const pfadfinderFarbe = Color(0xFF00823c);
+  static const roverFarbe = Color(0xFFcc1f2f);
+  static const leiterFarbe = Color(0xFFb1b9ad);
+  static const keineStufeFarbe = DPSGColors.leiterFarbe;
+}
+
 final darkTheme = ThemeData(
-  primarySwatch: Colors.blue,
-  primaryColor: const Color(0xFF1F1F1F),
-  brightness: Brightness.dark,
-  dividerColor: const Color(0xFFC9C9C9),
-  colorScheme: const ColorScheme(
-    primary: Color(0xff007bff),
-    primaryContainer: Color(0xff000000),
-    secondary: darkSecondary,
-    secondaryContainer: Color(0xff00bfa5),
-    surface: Color(0xff424242),
-    background: Color(0xff616161),
-    error: Color(0xffd32f2f),
-    onPrimary: Color(0xffffffff),
-    onSecondary: Color(0xff000000),
-    onSurface: Color(0xffffffff),
-    onBackground: Color(0xffffffff),
-    onError: Color(0xff000000),
+  colorScheme: ColorScheme.fromSeed(
+    seedColor: DPSGColors.primary,
+    secondary: DPSGColors.secondary,
     brightness: Brightness.dark,
-  ),
-  iconTheme: const IconThemeData(
-    color: Color(0xffffffff),
-    opacity: 1,
-    size: 24,
   ),
 );
 
 //################################################################
 
-const Color lightSecondary = Color(0xFF3D7BFF);
-
 final lightTheme = ThemeData(
-  primarySwatch: Colors.blue,
-  primaryColor: Colors.white,
-  brightness: Brightness.light,
-  dividerColor: const Color(0xFF616161),
-  colorScheme: const ColorScheme(
-    primary: Color(0xff007bff),
-    primaryContainer: Color(0xff000000),
-    secondary: lightSecondary,
-    secondaryContainer: Color(0xff00bfa5),
-    surface: Color(0xff424242),
-    background: Color(0xff616161),
-    error: Color(0xffd32f2f),
-    onPrimary: Color(0xffffffff),
-    onSecondary: Color(0xff000000),
-    onSurface: Color(0xffffffff),
-    onBackground: Color(0xffffffff),
-    onError: Color(0xff000000),
+  colorScheme: ColorScheme.fromSeed(
+    seedColor: DPSGColors.primary,
+    secondary: DPSGColors.secondary,
     brightness: Brightness.light,
-  ),
-  iconTheme: const IconThemeData(
-    color: Color(0xFF000000),
-    opacity: 1,
-    size: 24,
   ),
 );
 
-enum ThemeType { light, dark }
-
 class ThemeModel extends ChangeNotifier {
-  ThemeData currentTheme = darkTheme;
+  ThemeMode currentMode = ThemeMode.light;
 
-  setTheme(ThemeType type) {
-    if (type == ThemeType.light) {
-      currentTheme = lightTheme;
-      return notifyListeners();
-    }
-
-    if (type == ThemeType.dark) {
-      currentTheme = darkTheme;
-      return notifyListeners();
-    }
+  setTheme(ThemeMode type) {
+    currentMode = type;
+    return notifyListeners();
   }
 }


### PR DESCRIPTION
- Zuvor gab es zwei `MaterialApp`, ich habe die Struktur jetzt geändert, damit nur noch eine nötig ist
- `ThemeModel` gibt jetzt nicht mehr das verwendete Theme weiter, sondern nur noch den `ThemeMode`. `MaterialApp` besitzt beide themes, um sich standardmäßig dem System anzupassen.
- Ich habe die Stufenfarben in einer neuen Klasse gesammelt. Die Farben kommen aus den [offiziellen DPSG Farben](https://www.dpsg.de/sites/default/files/2021-04/dpsg_corporate_design_leitfaden.pdf)
- Ich habe ein einigen Stellen feste `Color` Werte entfernt und stattdessen Werte vom Theme genommen