### PR TITLE
feat: cookie and sync management

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,8 @@
 PODS:
+  - connectivity_plus (0.0.1):
+    - Flutter
+    - FlutterMacOS
+    - ReachabilitySwift
   - device_info_plus (0.0.1):
     - Flutter
   - Flutter (1.0.0)
@@ -20,6 +24,9 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - privacy_screen (0.0.1):
+    - Flutter
+  - ReachabilitySwift (5.2.1)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -28,6 +35,7 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - connectivity_plus (from `.symlinks/plugins/connectivity_plus/darwin`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
@@ -38,14 +46,18 @@ DEPENDENCIES:
   - maps_launcher (from `.symlinks/plugins/maps_launcher/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - privacy_screen (from `.symlinks/plugins/privacy_screen/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
+    - ReachabilitySwift
     - Toast
 
 EXTERNAL SOURCES:
+  connectivity_plus:
+    :path: ".symlinks/plugins/connectivity_plus/darwin"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
@@ -66,12 +78,15 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  privacy_screen:
+    :path: ".symlinks/plugins/privacy_screen/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
+  connectivity_plus: e2dad488011aeb593e219360e804c43cc1af5770
   device_info_plus: c6fb39579d0f423935b0c9ce7ee2f44b71b9fce6
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
@@ -82,6 +97,8 @@ SPEC CHECKSUMS:
   maps_launcher: 2e5b6a2d664ec6c27f82ffa81b74228d770ab203
   package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
+  privacy_screen: 1a131c052ceb3c3659934b003b0d397c2381a24e
+  ReachabilitySwift: 5ae15e16814b5f9ef568963fb2c87aeb49158c66
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   Toast: ec33c32b8688982cecc6348adeae667c1b9938da
   url_launcher_ios: bbd758c6e7f9fd7b5b1d4cde34d2b95fcce5e812

--- a/lib/screens/loading_info_screen.dart
+++ b/lib/screens/loading_info_screen.dart
@@ -108,6 +108,15 @@ class LoadingInfoScreenState extends State<LoadingInfoScreen> {
                   child: const Text(
                       'Keine Netzwerkverbindung. Versuch es später erneut'),
                 )
+              else if (context.watch<AppStateHandler>().syncState ==
+                  SyncState.relogin)
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                  child: const Text(
+                      'Kein Sync möglich ohne erneute Anmeldung. OK'),
+                )
             ],
           ),
         ));

--- a/lib/screens/loading_info_screen.dart
+++ b/lib/screens/loading_info_screen.dart
@@ -79,9 +79,8 @@ class LoadingInfoScreenState extends State<LoadingInfoScreen> {
                     'Meta', widget.metaProgressNotifier.value),
               _buildLoadingStatusRow('Member Overview',
                   widget.memberOverviewProgressNotifier.value),
-              if (widget.loadAll)
-                _buildLoadingStatusRow(
-                    'Member All', widget.memberAllProgressNotifier.value),
+              _buildLoadingStatusRow(
+                  'Member All', widget.memberAllProgressNotifier.value),
               if (_isDone)
                 ElevatedButton(
                   onPressed: () {

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -48,10 +48,9 @@ class LoginScreenState extends State<LoginScreen> {
       _wrongCredentials = true;
     });
     Timer(
-        const Duration(seconds: 3),
-        () => setState(() {
-              _wrongCredentials = false;
-            }));
+      const Duration(seconds: 3),
+      () => setState(() => _wrongCredentials = false),
+    );
   }
 
   Future<void> loginButtonPressed() async {
@@ -64,11 +63,19 @@ class LoginScreenState extends State<LoginScreen> {
       });
       if (_rememberMe) {
         setNamiPassword(_password);
+      } else {
+        deleteNamiPassword();
       }
       setNamiLoginId(_mitgliedsnummer);
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        AppStateHandler().setLoadDataState(context, loadAll: true);
-      });
+      if (AppStateHandler().currentState == AppState.loggedOut) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          AppStateHandler().setLoadDataState(loadAll: true);
+        });
+      } else if (AppStateHandler().currentState == AppState.relogin) {
+        /// setting to result to `true` to signal that the relogin was successful
+        // ignore: use_build_context_synchronously
+        Navigator.pop(context, true);
+      }
     } else {
       wrongCredentials();
       setState(() {

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -58,14 +58,14 @@ class LoginScreenState extends State<LoginScreen> {
     setState(() {
       _loading = true;
     });
+    final differentUser = _mitgliedsnummer != getNamiLoginId();
+    if (differentUser) {
+      logout();
+    }
     if (await namiLoginWithPassword(_mitgliedsnummer, _password)) {
       setState(() {
         _loading = false;
       });
-      final differentUser = _mitgliedsnummer != getNamiLoginId();
-      if (differentUser) {
-        logout();
-      }
       setNamiLoginId(_mitgliedsnummer);
       if (_rememberMe) {
         setNamiPassword(_password);

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:nami/utilities/hive/hive.handler.dart';
 import 'package:nami/utilities/hive/settings.dart';
 import 'package:nami/utilities/nami/nami-login.service.dart';
 import 'dart:async';
@@ -61,13 +62,18 @@ class LoginScreenState extends State<LoginScreen> {
       setState(() {
         _loading = false;
       });
+      final differentUser = _mitgliedsnummer != getNamiLoginId();
+      if (differentUser) {
+        logout();
+      }
+      setNamiLoginId(_mitgliedsnummer);
       if (_rememberMe) {
         setNamiPassword(_password);
       } else {
         deleteNamiPassword();
       }
-      setNamiLoginId(_mitgliedsnummer);
-      if (AppStateHandler().currentState == AppState.loggedOut) {
+      if (differentUser ||
+          AppStateHandler().currentState == AppState.loggedOut) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           AppStateHandler().setLoadDataState(loadAll: true);
         });

--- a/lib/screens/mitgliedsliste/mitglied_details.dart
+++ b/lib/screens/mitgliedsliste/mitglied_details.dart
@@ -14,7 +14,7 @@ import 'package:nami/utilities/hive/taetigkeit.dart';
 import 'package:maps_launcher/maps_launcher.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:intl/intl.dart';
-import 'package:nami/utilities/extensions.dart';
+import 'package:nami/utilities/types.dart';
 import 'package:wiredash/wiredash.dart';
 
 // ignore: must_be_immutable

--- a/lib/screens/mitgliedsliste/mitglied_liste.dart
+++ b/lib/screens/mitgliedsliste/mitglied_liste.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 // import 'package:hive/hive.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:nami/screens/mitgliedsliste/mitglied_details.dart';
-import 'package:nami/utilities/extensions.dart';
+import 'package:nami/utilities/types.dart';
 import 'package:nami/utilities/hive/mitglied.dart';
 import 'package:nami/utilities/mitglied.filterAndSort.dart';
 import 'package:nami/utilities/stufe.dart';

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -132,6 +132,20 @@ class _SettingsState extends State<Settings> {
     );
   }
 
+  _buildSyncOverWifiOnly() {
+    return ListTile(
+      title: const Text('Automatischer Sync nur über WLAN'),
+      leading: const Icon(Icons.wifi),
+      trailing: Switch(
+        value: getSyncOverWifiOnly(),
+        onChanged: (value) {
+          setSyncOverWifiOnly(value);
+          setState(() {});
+        },
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -146,6 +160,7 @@ class _SettingsState extends State<Settings> {
           const Divider(height: 1),
           _buildStufenwechselDatumInput(),
           _buildStammHeimInput(),
+          _buildSyncOverWifiOnly(),
         ],
       ),
     );

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -23,7 +23,7 @@ class _SettingsState extends State<Settings> {
       title: const Text('Aktualisiere die Mitgliedsdaten'),
       leading: const Icon(Icons.sync),
       onTap: () {
-        AppStateHandler().setLoadDataState(context, loadAll: false);
+        AppStateHandler().setLoadDataState(loadAll: false);
       },
       subtitle: Text(
           "Vor ${DateTime.now().difference(getLastNamiSync()).inDays.toString()} Tagen"),
@@ -35,7 +35,7 @@ class _SettingsState extends State<Settings> {
       title: const Text('Lade alle Daten neu'),
       leading: const Icon(Icons.sync),
       onTap: () {
-        AppStateHandler().setLoadDataState(context, loadAll: true);
+        AppStateHandler().setLoadDataState(loadAll: true);
       },
     );
   }

--- a/lib/utilities/app.state.dart
+++ b/lib/utilities/app.state.dart
@@ -86,7 +86,7 @@ class AppStateHandler extends ChangeNotifier {
 
   void showTooLongOfflineNotification() {
     showSnackBar(navigatorKey.currentContext!,
-        "Sie waren zu lange offline. Bitte melden Sie sich erneut an.");
+        "Du warst zu lange offline. Bitte melde dich erneut an.");
   }
 
   /// Returns true when relogin was successful
@@ -100,7 +100,7 @@ class AppStateHandler extends ChangeNotifier {
     } else {
       showLogin = await showConfirmationDialog(
         "Sitzung abgelaufen",
-        "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an.",
+        "Deine Sitzung ist abgelaufen. Bitte melden dich erneut an.",
       );
     }
     if (showLogin) {
@@ -129,7 +129,9 @@ class AppStateHandler extends ChangeNotifier {
     ValueNotifier<double> memberAllProgressNotifier = ValueNotifier(0.0);
 
     syncState = SyncState.loading;
-    if (!background) {
+    if (background) {
+      showSnackBar(navigatorKey.currentContext!, "Daten werden synchronisiert");
+    } else {
       navigatorKey.currentState!.push(
         MaterialPageRoute(builder: (context) {
           return LoadingInfoScreen(
@@ -157,6 +159,10 @@ class AppStateHandler extends ChangeNotifier {
       );
       rechteProgressNotifier.value = await getRechte();
       syncState = SyncState.successful;
+      if (background) {
+        showSnackBar(navigatorKey.currentContext!,
+            "Daten wurden erfolgreich synchronisiert");
+      }
       setReadyState();
     } on SessionExpired catch (_) {
       debugPrint('sync failed with session expired');
@@ -171,8 +177,16 @@ class AppStateHandler extends ChangeNotifier {
         if (isTooLongOffline()) {
           syncState = SyncState.error;
           if (background) {
+            showSnackBar(navigatorKey.currentContext!,
+                'Du wirst ausgeloggt, da du zu lange offline warst.');
             setLoggedOutState();
           }
+          // if not [background] the user will be logged out in
+          // [LoadingInfoScreen] when pressing the button
+        }
+        if (background) {
+          showSnackBar(navigatorKey.currentContext!,
+              'Kein Sync möglich ohne erneute Anmeldung.');
         }
         syncState = SyncState.relogin;
         setReadyState();

--- a/lib/utilities/custom_drawer/home_drawer.dart
+++ b/lib/utilities/custom_drawer/home_drawer.dart
@@ -145,7 +145,7 @@ class HomeDrawerState extends State<HomeDrawer> {
                   color: Colors.red,
                 ),
                 onTap: () {
-                  AppStateHandler().setLoggedOutState(context);
+                  AppStateHandler().setLoggedOutState();
                 },
               ),
               SizedBox(

--- a/lib/utilities/hive/hive.handler.dart
+++ b/lib/utilities/hive/hive.handler.dart
@@ -12,6 +12,7 @@ void logout() {
   Hive.box<Mitglied>('members').clear();
   deleteGruppierungId();
 
+  setStammheim('');
   // login data
   deleteNamiApiCookie();
   deleteNamiLoginId();
@@ -19,6 +20,7 @@ void logout() {
 
   // other Stuff
   deleteLastLoginCheck();
+  deleteLastNamiSyncTry();
   deleteLastNamiSync();
 }
 

--- a/lib/utilities/hive/settings.dart
+++ b/lib/utilities/hive/settings.dart
@@ -12,6 +12,7 @@ enum SettingValue {
   lastNamiSync,
   lastNamiSyncTry,
   lastLoginCheck,
+  syncOverWifiOnly,
   stufenwechselDatum,
   stammheim,
   metaGeschechtOptions,
@@ -137,6 +138,10 @@ void setLastLoginCheck(DateTime lastLoginCheck) {
       .put(SettingValue.lastLoginCheck.toString(), lastLoginCheck);
 }
 
+void setSyncOverWifiOnly(bool value) {
+  Hive.box('settingsBox').put(SettingValue.syncOverWifiOnly.toString(), value);
+}
+
 String getNamiApiCookie() {
   return Hive.box('settingsBox').get(SettingValue.namiApiCookie.toString()) ??
       '';
@@ -145,6 +150,12 @@ String getNamiApiCookie() {
 DateTime getLastLoginCheck() {
   return Hive.box('settingsBox').get(SettingValue.lastLoginCheck.toString()) ??
       DateTime.utc(1989, 1, 1);
+}
+
+bool getSyncOverWifiOnly() {
+  return Hive.box('settingsBox')
+          .get(SettingValue.syncOverWifiOnly.toString()) ??
+      true;
 }
 
 DateTime getNextStufenwechselDatum() {

--- a/lib/utilities/hive/settings.dart
+++ b/lib/utilities/hive/settings.dart
@@ -10,6 +10,7 @@ enum SettingValue {
   gruppierungId,
   gruppierungName,
   lastNamiSync,
+  lastNamiSyncTry,
   lastLoginCheck,
   stufenwechselDatum,
   stammheim,
@@ -126,6 +127,11 @@ void setLastNamiSync(DateTime lastNamiSync) {
       .put(SettingValue.lastNamiSync.toString(), lastNamiSync);
 }
 
+void setLastNamiSyncTry(DateTime lastNamiSyncTry) {
+  Hive.box('settingsBox')
+      .put(SettingValue.lastNamiSyncTry.toString(), lastNamiSyncTry);
+}
+
 void setLastLoginCheck(DateTime lastLoginCheck) {
   Hive.box('settingsBox')
       .put(SettingValue.lastLoginCheck.toString(), lastLoginCheck);
@@ -200,6 +206,11 @@ DateTime getLastNamiSync() {
       DateTime.utc(1989, 1, 1);
 }
 
+DateTime getLastNamiSyncTry() {
+  return Hive.box('settingsBox').get(SettingValue.lastNamiSyncTry.toString()) ??
+      DateTime.utc(1989, 1, 1);
+}
+
 void deleteNamiApiCookie() {
   Hive.box('settingsBox').delete(SettingValue.namiApiCookie.toString());
 }
@@ -210,6 +221,10 @@ void deleteLastLoginCheck() {
 
 void deleteLastNamiSync() {
   Hive.box('settingsBox').delete(SettingValue.lastNamiSync.toString());
+}
+
+void deleteLastNamiSyncTry() {
+  Hive.box('settingsBox').delete(SettingValue.lastNamiSyncTry.toString());
 }
 
 void deleteNamiLoginId() {

--- a/lib/utilities/nami/nami-member.service.dart
+++ b/lib/utilities/nami/nami-member.service.dart
@@ -159,7 +159,7 @@ Future<void> syncMember(
   var futures = <Future>[];
 
   for (var mitgliedId in mitgliedIds) {
-    futures.add(storeMitgliedToHive(
+    futures.add(_storeMitgliedToHive(
         mitgliedId,
         memberBox,
         url,
@@ -175,7 +175,7 @@ Future<void> syncMember(
   debugPrint('Syncronisation der Mitgliedsdetails abgeschlossen');
 }
 
-Future<void> storeMitgliedToHive(
+Future<void> _storeMitgliedToHive(
     int mitgliedId,
     Box<Mitglied> memberBox,
     String url,

--- a/lib/utilities/nami/nami-member.service.dart
+++ b/lib/utilities/nami/nami-member.service.dart
@@ -126,6 +126,7 @@ Future<void> syncMember(
   ValueNotifier<bool?> memberOverviewProgressNotifier, {
   bool forceUpdate = false,
 }) async {
+  setLastNamiSyncTry(DateTime.now());
   int gruppierung = getGruppierungId()!;
   String cookie = getNamiApiCookie();
   String url = getNamiLUrl();

--- a/lib/utilities/nami/nami-member.service.dart
+++ b/lib/utilities/nami/nami-member.service.dart
@@ -104,6 +104,7 @@ Future<List<NamiMemberTaetigkeitenModel>> _loadMemberTaetigkeiten(
   }
 }
 
+// ignore: unused_element
 Future<NamiMemberTaetigkeitenModel?> _loadMemberTaetigkeit(int memberId,
     int taetigkeitId, String url, String path, String cookie) async {
   String fullUrl =

--- a/lib/utilities/nami/nami.service.dart
+++ b/lib/utilities/nami/nami.service.dart
@@ -56,7 +56,7 @@ Future<Document> withMaybeRetryHTML(Future<http.Response> Function() func,
   if (response.statusCode == 200) {
     return html;
   } else if (response.statusCode == 500 &&
-      response.body.contains("Session expired")) {
+      response.body.toLowerCase().contains("session expired")) {
     final success = await updateLoginData();
     if (success) {
       final response = await func();

--- a/lib/utilities/nami/nami.service.dart
+++ b/lib/utilities/nami/nami.service.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:html/dom.dart';
+import 'package:html/parser.dart';
 import 'package:http/http.dart' as http;
 import 'package:nami/utilities/hive/settings.dart';
 import 'package:nami/utilities/nami/nami-login.service.dart';
@@ -14,7 +16,8 @@ import 'package:nami/utilities/nami/nami_member_add_meta.dart';
 /// Throws [SessionExpired] if that's not possible
 ///
 /// Remeber to obtain the cookie in [func] to always use the latest one.
-dynamic withMaybeRetry(Future<http.Response> Function() func) async {
+dynamic withMaybeRetry(Future<http.Response> Function() func,
+    [String? errorMessage]) async {
   final response = await func();
   late final body = jsonDecode(response.body);
   if (response.statusCode == 200 && body['success']) {
@@ -34,7 +37,41 @@ dynamic withMaybeRetry(Future<http.Response> Function() func) async {
       throw SessionExpired();
     }
   } else {
-    throw Exception('Failed to load with status code ${response.statusCode}');
+    throw Exception(
+        'Failed to load with status code ${response.statusCode}. Custom Message: $errorMessage');
+  }
+}
+
+/// Calls [func] and returns the html body if reuqest ws succsessful
+///
+/// If the request failes with an expired session, it tries to get a new cookie
+/// with saved password and retries [func].
+/// Throws [SessionExpired] if that's not possible
+///
+/// Remeber to obtain the cookie in [func] to always use the latest one.
+Future<Document> withMaybeRetryHTML(Future<http.Response> Function() func,
+    [String? errorMessage]) async {
+  final response = await func();
+  late final html = parse(response.body);
+  if (response.statusCode == 200) {
+    return html;
+  } else if (response.statusCode == 500 &&
+      response.body.contains("Session expired")) {
+    final success = await updateLoginData();
+    if (success) {
+      final response = await func();
+      late final html = parse(response.body);
+      if (response.statusCode == 200) {
+        return html;
+      } else {
+        throw SessionExpired();
+      }
+    } else {
+      throw SessionExpired();
+    }
+  } else {
+    throw Exception(
+        'Failed to load with status code ${response.statusCode}. Custom Message: $errorMessage');
   }
 }
 
@@ -69,19 +106,19 @@ Future<String> loadGruppierung() async {
   }
 
   debugPrint('Request: Lade Gruppierung');
-  final response =
-      await http.get(Uri.parse(fullUrl), headers: {'Cookie': cookie});
+  final body = await withMaybeRetry(() async {
+    final cookie = getNamiApiCookie();
+    return await http.get(Uri.parse(fullUrl), headers: {'Cookie': cookie});
+  });
 
-  if (response.statusCode != 200 ||
-      !jsonDecode(response.body)['success'] ||
-      jsonDecode(response.body)['data'].length != 1) {
+  if (body['data'].length != 1) {
     debugPrint(
         'Failed to load gruppierung. Multiple or no gruppierungen found');
     throw Exception('Failed to load gruppierung');
   }
 
-  int gruppierungId = jsonDecode(response.body)['data'][0]['id'];
-  String gruppierungName = jsonDecode(response.body)['data'][0]['descriptor'];
+  int gruppierungId = body['data'][0]['id'];
+  String gruppierungName = body['data'][0]['descriptor'];
   setGruppierungId(gruppierungId);
   setGruppierungName(gruppierungName);
   debugPrint('Gruppierung: $gruppierungName ($gruppierungId)');

--- a/lib/utilities/nami/nami_user_data.dart
+++ b/lib/utilities/nami/nami_user_data.dart
@@ -2,11 +2,10 @@ import 'package:hive/hive.dart';
 import 'package:nami/utilities/hive/mitglied.dart';
 import 'package:nami/utilities/hive/settings.dart';
 
-List<Mitglied> mitglieder =
-    Hive.box<Mitglied>('members').values.toList().cast<Mitglied>();
-
 // find user by id in mitglied list
 Mitglied? findMitgliedById(int id) {
+  List<Mitglied> mitglieder =
+      Hive.box<Mitglied>('members').values.toList().cast<Mitglied>();
   for (var mitglied in mitglieder) {
     if (mitglied.mitgliedsNummer == id) {
       return mitglied;

--- a/lib/utilities/notifications.dart
+++ b/lib/utilities/notifications.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:nami/main.dart';
 
 void showErrorSnackBar(BuildContext context, String message) {
   ScaffoldMessenger.of(context).showSnackBar(
@@ -12,4 +13,44 @@ void showErrorSnackBar(BuildContext context, String message) {
       backgroundColor: Theme.of(context).colorScheme.errorContainer,
     ),
   );
+}
+
+void showSnackBar(BuildContext context, String message) {
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+      content: Text(
+        message,
+      ),
+    ),
+  );
+}
+
+Future<bool> showConfirmationDialog(
+  String title,
+  String message,
+) async {
+  return await showDialog<bool>(
+          context: navigatorKey.currentContext!,
+          barrierDismissible: false,
+          builder: (BuildContext context) {
+            return AlertDialog(
+              title: Text(title),
+              content: Text(message),
+              actions: <Widget>[
+                TextButton(
+                  child: const Text('Abbrechen'),
+                  onPressed: () {
+                    Navigator.of(context).pop(false);
+                  },
+                ),
+                TextButton(
+                  child: const Text('Bestätigen'),
+                  onPressed: () {
+                    Navigator.of(context).pop(true);
+                  },
+                ),
+              ],
+            );
+          }) ??
+      false;
 }

--- a/lib/utilities/types.dart
+++ b/lib/utilities/types.dart
@@ -8,3 +8,5 @@ extension DateTimeExtension on DateTime {
     return "${day < 10 ? '0' : ''}$day.${month < 10 ? '0' : ''}$month.$year";
   }
 }
+
+class SessionExpired implements Exception {}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -177,6 +177,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: e9feae83b1849f61bad9f6f33ee00646e3410d54ce0821e02f262f9901dad3c9
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.1"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: b6a56efe1e6675be240de39107281d4034b64ac23438026355b4234042a35adb
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   convert:
     dependency: transitive
     description:
@@ -225,6 +241,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.4"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.10"
   device_info_plus:
     dependency: transitive
     description:
@@ -782,6 +806,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   node_preamble:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   flutter_dotenv: ^5.1.0
   privacy_screen: ^0.0.6
   faker: ^2.0.0
+  connectivity_plus: ^6.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Diese pr ist größer geworden als erwartet und hat einige Stunden gebraucht, aber es musste gefühlt alles im `AppStateHandler` geändert werden.

## Ziele und Umsetzung
- Requests zum Nami Server sollen automatisch wiederholt werden, wenn der cookie abgelaufen ist. Dabei wird wenn das Passwort gespeichert ist, versucht ein neuer cookie zu erstellen und die eigentliche Anfrage zu wiederholen. Wenn nicht wird jetzt eine `SessionExpired` exception geworfen
- Die Aufgabe des Frontends ist es dann eine `SessionExpired` zu fangen und entsprechend reagieren. Dazu muss dann `setReloginState()` aufgerufen werden. Dabei wird der Nutzer wieder auf die Loginseite geleitet, ohne aber alle Nutzerdaten zu löschen. Nach einer erfolgreichen Anmeldung, landet man wieder auf derselben Seite wie vor dem relogin. Anschließend kann dann zum Beispiel der sync nochmal versucht werden, etc. Der Fokus und Schwierigkeit lag dabei an der selben Stelle wie vor der erneuten Authentifizierung weiter machen zu können.
- Alle 24h wird im Hintergrund ein neuer sync gestartet. Wenn man offline ist, ist das für 30 Tage okay. Danach muss man aber wieder online gehen und einen neuen sync machen. Wenn man das Passwort nicht speichert bedeutet das aktuell, dass man alle 24h na h einer neuen Anmeldung gefragt wird. Man kann es 39 Tage lang ignorieren.
- Es wurden einige AppStates entfernt, da ich sie nicht für relevant erachtet habe und stattdessen jetzt z.B. im `SyncState` sind. Ein bug war zum Beispiel vorher, dass sich die Textfelder auf der Loginseite resettet haben, wenn man die App kurz verlassen hat. Das war sehr nervig, wenn man z.B. Passwort und Nutzername aus einer anderen App kopieren wollte.

### TODO für diese PR, wenn Prinzip abgenommen
~~- Noch sind nicht alle nami apis mit `withMaybeRetry` wrapped~~

close #41