### PR TITLE
fix: retry on wrong birthday of member

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -161,6 +161,7 @@ class LoginScreenState extends State<LoginScreen> {
             onChanged: (text) {
               _password = text;
             },
+            onSubmitted: (_) => loginButtonPressed(),
             obscureText: true,
             autofillHints: const [AutofillHints.password],
             style: const TextStyle(

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -121,6 +121,7 @@ class LoginScreenState extends State<LoginScreen> {
                 return oldValue;
               }),
             ],
+            textInputAction: TextInputAction.next,
             keyboardType: TextInputType.number,
             autofillHints: const [AutofillHints.username],
             style: const TextStyle(

--- a/lib/utilities/nami/nami-member.service.dart
+++ b/lib/utilities/nami/nami-member.service.dart
@@ -75,7 +75,8 @@ Future<NamiMemberDetailsModel> _loadMemberDetails(
         NamiMemberDetailsModel.fromJson(source['data']);
     if (DateTime.now().difference(member.geburtsDatum).inDays > 36525) {
       debugPrint(
-          'Geburtsdatum von $id (${member.vorname}) ist fehlerhaft: ${member.geburtsDatum}');
+          'Geburtsdatum von $id (${member.vorname}) ist fehlerhaft: ${member.geburtsDatum}. Versuche es erneut.');
+      return await _loadMemberDetails(id, url, path, gruppierung, cookie);
     }
     return member;
   } else {


### PR DESCRIPTION
Bei falschem Geburtsdatum wird eine erneute Anfrage gesendet.

Außerdem habe ich unabhängig von dem Thema noch `TextInputAction.next` zum id Feld auf der Login Seite hinzugefügt, damit man über die Tastatur zum nächsten Feld kommt.

close #60 