### PR TITLE
fix: show relogin from background sync as banner

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_map_tile_caching/flutter_map_tile_caching.dart';
 import 'package:hive_flutter/hive_flutter.dart';
@@ -29,15 +30,17 @@ void main() async {
   await openHive();
   await dotenv.load(fileName: ".env");
   await initLogger();
-  await PrivacyScreen.instance.enable(
-    iosOptions: const PrivacyIosOptions(
-      enablePrivacy: true,
-      lockTrigger: IosLockTrigger.didEnterBackground,
-    ),
-    androidOptions: const PrivacyAndroidOptions(
-      enableSecure: true,
-    ),
-  );
+  if (!kDebugMode) {
+    await PrivacyScreen.instance.enable(
+      iosOptions: const PrivacyIosOptions(
+        enablePrivacy: true,
+        lockTrigger: IosLockTrigger.didEnterBackground,
+      ),
+      androidOptions: const PrivacyAndroidOptions(
+        enableSecure: true,
+      ),
+    );
+  }
   runApp(
     ChangeNotifierProvider<ThemeModel>(
       create: (_) => ThemeModel(),

--- a/lib/screens/mitgliedsliste/mitglied_liste.dart
+++ b/lib/screens/mitgliedsliste/mitglied_liste.dart
@@ -4,6 +4,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:intl/intl.dart';
 import 'package:nami/screens/mitgliedsliste/mitglied_details.dart';
 import 'package:nami/screens/mitgliedsliste/mitglied_liste_filter.dart';
+import 'package:nami/screens/widgets/relogin_banner.dart';
 import 'package:nami/utilities/hive/mitglied.dart';
 import 'package:nami/utilities/hive/settings.dart';
 import 'package:nami/utilities/mitglied.filterAndSort.dart';
@@ -276,6 +277,7 @@ class MitgliedsListeState extends State<MitgliedsListe> {
         ),
         body: Column(
           children: <Widget>[
+            const ReloginBanner(),
             _buildFilterGroup(),
             _buildSearchBar(),
             Expanded(

--- a/lib/screens/widgets/relogin_banner.dart
+++ b/lib/screens/widgets/relogin_banner.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:nami/utilities/app.state.dart';
+import 'package:provider/provider.dart';
+
+class ReloginBanner extends StatelessWidget {
+  const ReloginBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final syncState = context.watch<AppStateHandler>().syncState;
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      transitionBuilder: (child, animation) {
+        return SizeTransition(
+          sizeFactor: animation,
+          axisAlignment: -1,
+          child: child,
+        );
+      },
+      child: syncState == SyncState.relogin
+          ? MaterialBanner(
+              leading: Icon(Icons.sync_problem,
+                  color: Theme.of(context).colorScheme.error),
+              content: const Text(
+                  'Deine Sitzung ist abgelaufen, weshalb der tägliche Sync fehlschlug.'),
+              actions: [
+                TextButton(
+                  child: const Text('Abbrechen'),
+                  onPressed: () {
+                    context.read<AppStateHandler>().syncState =
+                        SyncState.notStarted;
+                  },
+                ),
+                ElevatedButton(
+                  child: const Text('Anmelden'),
+                  onPressed: () async {
+                    final appStateHandler = context.read<AppStateHandler>();
+                    final successfulRelogin = await appStateHandler
+                        .setReloginState(showDialog: false);
+                    if (successfulRelogin) {
+                      appStateHandler.setLoadDataState(
+                          background: true, loadAll: false);
+                    }
+                  },
+                ),
+              ],
+            )
+          : const SizedBox(),
+    );
+  }
+}

--- a/lib/utilities/app.state.dart
+++ b/lib/utilities/app.state.dart
@@ -99,14 +99,17 @@ class AppStateHandler extends ChangeNotifier {
   /// Returns true when relogin was successful
   ///
   /// See [AppState.relogin] for more information
-  Future<bool> setReloginState() async {
+  ///
+  /// Setting [showDialog] to false prevents the dialog to ask for relogin.
+  /// Instead it will directly show the login screen.
+  Future<bool> setReloginState({showDialog = true}) async {
     sensLog.i('Start relogin');
     var showLogin = true;
     final tooLongOffline = isTooLongOffline();
     if (tooLongOffline) {
       sensLog.i('too long offline, show too long offline notification');
       showTooLongOfflineNotification();
-    } else {
+    } else if (showDialog) {
       showLogin = await showConfirmationDialog(
         "Sitzung abgelaufen",
         "Deine Sitzung ist abgelaufen. Bitte melden dich erneut an.",
@@ -180,32 +183,30 @@ class AppStateHandler extends ChangeNotifier {
     } on SessionExpired catch (_) {
       sensLog.i('sync failed with session expired');
       syncState = SyncState.relogin;
-      if (await setReloginState()) {
-        if (!background) {
+      if (!background) {
+        // not setting relogin state when in background as it's done by [ReloginBanner]
+        if (await setReloginState()) {
           /// pop with false to prevent going to ready or loggedOut state
           navigatorKey.currentState!.pop();
+          setLoadDataState(loadAll: loadAll, background: background);
         }
-        setLoadDataState(loadAll: loadAll, background: background);
-      } else {
-        if (isTooLongOffline()) {
-          syncState = SyncState.error;
-          sensLog.i('sync failed with too long offline');
-          if (background) {
-            showSnackBar(navigatorKey.currentContext!,
-                'Du wirst ausgeloggt, da du zu lange offline warst.');
-            setLoggedOutState();
-          }
-          // if not [background] the user will be logged out in
-          // [LoadingInfoScreen] when pressing the button
-          return;
-        }
+      }
+      if (isTooLongOffline()) {
+        syncState = SyncState.error;
+        sensLog.i('sync failed with too long offline');
         if (background) {
           showSnackBar(navigatorKey.currentContext!,
-              'Kein Sync möglich ohne erneute Anmeldung.');
+              'Du wirst ausgeloggt, da du zu lange offline warst.');
+          setLoggedOutState();
         }
-        syncState = SyncState.relogin;
-        setReadyState();
+        // if not [background] the user will be logged out in
+        // [LoadingInfoScreen] when pressing the button
+        return;
       }
+      showSnackBar(navigatorKey.currentContext!,
+          'Deine Sitzung ist abgelaufen, weshalb der tägliche Sync fehlschlug.');
+      syncState = SyncState.relogin;
+      setReadyState();
     } catch (e, st) {
       if (e is http.ClientException || e is TimeoutException) {
         sensLog.i('sync failed with no internet connection');

--- a/lib/utilities/hive/hive.handler.dart
+++ b/lib/utilities/hive/hive.handler.dart
@@ -3,11 +3,13 @@ import 'package:nami/utilities/hive/settings.dart';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:nami/utilities/hive/taetigkeit.dart';
+import 'package:nami/utilities/logger.dart';
 import 'dart:convert';
 
 import 'mitglied.dart';
 
 void logout() {
+  sensLog.i('in logout');
   //loaded Data
   Hive.box<Mitglied>('members').clear();
   deleteGruppierungId();


### PR DESCRIPTION
- Wenn beim background sync die Session ausgelaufen ist, wird kein Dialog mehr angezeigt, sondern stattdessen in der Mitgliederliste ein Banner mit den Informationen.
- Privacy Screen wird im debug modus nicht eingeschalten, um für Testzwecke Screenshots zu ermöglichen.
- `logout` wird nun bei Aufruf protokolliert.