### PR TITLE
feat/ausbildung

### DIFF
--- a/lib/screens/mitgliedsliste/mitglied_details.dart
+++ b/lib/screens/mitgliedsliste/mitglied_details.dart
@@ -36,8 +36,11 @@ class MitgliedDetailState extends State<MitgliedDetail>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 2, vsync: this);
+    _tabController =
+        TabController(length: showAusbildungen ? 3 : 2, vsync: this);
   }
+
+  bool get showAusbildungen => widget.mitglied.ausbildungen.isNotEmpty;
 
   Widget _buildBox(Widget child) {
     return Card(
@@ -464,86 +467,103 @@ class MitgliedDetailState extends State<MitgliedDetail>
     Taetigkeit? fakeStufenwechselTaetigkeit = getStufenwechselTaetigkeit();
     Taetigkeit? currentTaetigkeit = getCurrenttaetigkeit(aktiveTaetigkeiten);
     return Scaffold(
-        floatingActionButton: FloatingActionButton(
-          onPressed: () => openWiredash(context),
-          child: const Icon(Icons.feedback),
-        ),
-        appBar: AppBar(
-          shadowColor: Colors.transparent,
-          backgroundColor: Stufe.getStufeByString(widget.mitglied.stufe).farbe,
-          title: Text("${widget.mitglied.vorname} ${widget.mitglied.nachname}"),
-          actions: [
-            IconButton(
-                onPressed: () => {
-                      isFavourit
-                          ? removeFavouriteList(widget.mitglied.mitgliedsNummer)
-                          : addFavouriteList(widget.mitglied.mitgliedsNummer),
-                      setState(() {
-                        isFavourit = !isFavourit;
-                      })
-                    },
-                icon: isFavourit
-                    ? const Icon(Icons.star)
-                    : const Icon(Icons.star_border_outlined))
-          ],
-        ),
-        body: Column(
-          children: <Widget>[
-            _buildStatistikTopRow(),
-            TabBar(
-              controller: _tabController,
-              tabs: const [
-                Tab(text: 'Kontaktdaten'),
-                Tab(text: 'Tätigkeiten'),
-              ],
-            ),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: TabBarView(
-                  controller: _tabController,
-                  children: [
-                    ListView(
-                      children: <Widget>[
-                        _buildGeneralInfos(),
-                        _buildAddress(),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => openWiredash(context),
+        child: const Icon(Icons.feedback),
+      ),
+      appBar: AppBar(
+        shadowColor: Colors.transparent,
+        backgroundColor: Stufe.getStufeByString(widget.mitglied.stufe).farbe,
+        title: Text("${widget.mitglied.vorname} ${widget.mitglied.nachname}"),
+        actions: [
+          IconButton(
+              onPressed: () => {
+                    isFavourit
+                        ? removeFavouriteList(widget.mitglied.mitgliedsNummer)
+                        : addFavouriteList(widget.mitglied.mitgliedsNummer),
+                    setState(() {
+                      isFavourit = !isFavourit;
+                    })
+                  },
+              icon: isFavourit
+                  ? const Icon(Icons.star)
+                  : const Icon(Icons.star_border_outlined))
+        ],
+      ),
+      body: Column(
+        children: <Widget>[
+          _buildStatistikTopRow(),
+          TabBar(
+            controller: _tabController,
+            tabs: [
+              const Tab(text: 'Basisdaten'),
+              const Tab(text: 'Tätigkeiten'),
+              if (showAusbildungen) const Tab(text: 'Ausbildungen')
+            ],
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: TabBarView(
+                controller: _tabController,
+                children: [
+                  ListView(
+                    children: <Widget>[
+                      _buildGeneralInfos(),
+                      _buildAddress(),
+                    ],
+                  ),
+                  ListView(
+                    children: [
+                      if (kDebugMode &&
+                          fakeStufenwechselTaetigkeit != null &&
+                          currentTaetigkeit != null) ...[
+                        Text(
+                          'Zukünftige Tätigkeit',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        _buildStufenwechselItem(
+                            fakeStufenwechselTaetigkeit, currentTaetigkeit),
+                        const SizedBox(height: 10),
                       ],
-                    ),
+                      if (aktiveTaetigkeiten.isNotEmpty)
+                        Text(
+                          'Aktive Tätigkeiten',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                      for (final taetigkeit in aktiveTaetigkeiten)
+                        _buildTaetigkeitenItem(taetigkeit),
+                      const SizedBox(height: 10),
+                      if (vergangeneTaetigkeiten.isNotEmpty)
+                        Text(
+                          'Abgeschlossene Tätigkeiten',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                      for (final taetigkeit in vergangeneTaetigkeiten)
+                        _buildTaetigkeitenItem(taetigkeit),
+                    ],
+                  ),
+                  if (showAusbildungen)
                     ListView(
                       children: [
-                        if (kDebugMode &&
-                            fakeStufenwechselTaetigkeit != null &&
-                            currentTaetigkeit != null) ...[
-                          Text(
-                            'Zukünftige Tätigkeit',
-                            style: Theme.of(context).textTheme.titleMedium,
+                        for (final ausbildung in widget.mitglied.ausbildungen)
+                          _buildBox(
+                            ListTile(
+                              leading: const Icon(Icons.school),
+                              title: Text(ausbildung.baustein),
+                              isThreeLine: true,
+                              subtitle: Text(
+                                  '${ausbildung.name}\n${DateFormat('dd. MMMM yyyy').format(ausbildung.datum)} - ${ausbildung.veranstalter}'),
+                            ),
                           ),
-                          _buildStufenwechselItem(
-                              fakeStufenwechselTaetigkeit, currentTaetigkeit),
-                          const SizedBox(height: 10),
-                        ],
-                        if (aktiveTaetigkeiten.isNotEmpty)
-                          Text(
-                            'Aktive Tätigkeiten',
-                            style: Theme.of(context).textTheme.titleMedium,
-                          ),
-                        for (final taetigkeit in aktiveTaetigkeiten)
-                          _buildTaetigkeitenItem(taetigkeit),
-                        const SizedBox(height: 10),
-                        if (vergangeneTaetigkeiten.isNotEmpty)
-                          Text(
-                            'Abgeschlossene Tätigkeiten',
-                            style: Theme.of(context).textTheme.titleMedium,
-                          ),
-                        for (final taetigkeit in vergangeneTaetigkeiten)
-                          _buildTaetigkeitenItem(taetigkeit),
                       ],
-                    )
-                  ],
-                ),
+                    ),
+                ],
               ),
             ),
-          ],
-        ));
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/utilities/hive/ausbildung.dart
+++ b/lib/utilities/hive/ausbildung.dart
@@ -1,0 +1,24 @@
+import 'package:hive/hive.dart';
+part 'ausbildung.g.dart';
+
+// flutter packages pub run build_runner build
+@HiveType(typeId: 3)
+class Ausbildung {
+  @HiveField(0)
+  late int id;
+
+  @HiveField(1)
+  late DateTime datum;
+
+  @HiveField(2)
+  late String veranstalter;
+
+  @HiveField(3)
+  late String name;
+
+  @HiveField(4)
+  late String baustein;
+
+  @HiveField(5)
+  late String? descriptor;
+}

--- a/lib/utilities/hive/ausbildung.dart
+++ b/lib/utilities/hive/ausbildung.dart
@@ -18,7 +18,4 @@ class Ausbildung {
 
   @HiveField(4)
   late String baustein;
-
-  @HiveField(5)
-  String? descriptor;
 }

--- a/lib/utilities/hive/ausbildung.dart
+++ b/lib/utilities/hive/ausbildung.dart
@@ -20,5 +20,5 @@ class Ausbildung {
   late String baustein;
 
   @HiveField(5)
-  late String? descriptor;
+  String? descriptor;
 }

--- a/lib/utilities/hive/ausbildung.g.dart
+++ b/lib/utilities/hive/ausbildung.g.dart
@@ -1,0 +1,55 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ausbildung.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class AusbildungAdapter extends TypeAdapter<Ausbildung> {
+  @override
+  final int typeId = 3;
+
+  @override
+  Ausbildung read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return Ausbildung()
+      ..id = fields[0] as int
+      ..datum = fields[1] as DateTime
+      ..veranstalter = fields[2] as String
+      ..name = fields[3] as String
+      ..baustein = fields[4] as String
+      ..descriptor = fields[5] as String?;
+  }
+
+  @override
+  void write(BinaryWriter writer, Ausbildung obj) {
+    writer
+      ..writeByte(6)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.datum)
+      ..writeByte(2)
+      ..write(obj.veranstalter)
+      ..writeByte(3)
+      ..write(obj.name)
+      ..writeByte(4)
+      ..write(obj.baustein)
+      ..writeByte(5)
+      ..write(obj.descriptor);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AusbildungAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/utilities/hive/ausbildung.g.dart
+++ b/lib/utilities/hive/ausbildung.g.dart
@@ -21,14 +21,13 @@ class AusbildungAdapter extends TypeAdapter<Ausbildung> {
       ..datum = fields[1] as DateTime
       ..veranstalter = fields[2] as String
       ..name = fields[3] as String
-      ..baustein = fields[4] as String
-      ..descriptor = fields[5] as String?;
+      ..baustein = fields[4] as String;
   }
 
   @override
   void write(BinaryWriter writer, Ausbildung obj) {
     writer
-      ..writeByte(6)
+      ..writeByte(5)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -38,9 +37,7 @@ class AusbildungAdapter extends TypeAdapter<Ausbildung> {
       ..writeByte(3)
       ..write(obj.name)
       ..writeByte(4)
-      ..write(obj.baustein)
-      ..writeByte(5)
-      ..write(obj.descriptor);
+      ..write(obj.baustein);
   }
 
   @override

--- a/lib/utilities/hive/hive.handler.dart
+++ b/lib/utilities/hive/hive.handler.dart
@@ -1,4 +1,5 @@
 import 'package:hive/hive.dart';
+import 'package:nami/utilities/hive/ausbildung.dart';
 import 'package:nami/utilities/hive/settings.dart';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -31,6 +32,7 @@ void logout() {
 Future<void> registerAdapter() async {
   try {
     Hive.registerAdapter(TaetigkeitAdapter());
+    Hive.registerAdapter(AusbildungAdapter());
     Hive.registerAdapter(MitgliedAdapter());
   } catch (_) {}
 }

--- a/lib/utilities/hive/mitglied.dart
+++ b/lib/utilities/hive/mitglied.dart
@@ -1,4 +1,5 @@
 import 'package:hive/hive.dart';
+import 'package:nami/utilities/hive/ausbildung.dart';
 import 'package:nami/utilities/hive/settings.dart';
 import 'package:nami/utilities/hive/taetigkeit.dart';
 
@@ -81,6 +82,9 @@ class Mitglied {
 
   @HiveField(24)
   late List<Taetigkeit> taetigkeiten;
+
+  @HiveField(25, defaultValue: [])
+  late List<Ausbildung> ausbildungen;
 
   bool isMitgliedLeiter() {
     for (Taetigkeit t in taetigkeiten) {

--- a/lib/utilities/hive/mitglied.g.dart
+++ b/lib/utilities/hive/mitglied.g.dart
@@ -40,13 +40,14 @@ class MitgliedAdapter extends TypeAdapter<Mitglied> {
       ..mglTypeId = fields[21] as String
       ..beitragsartId = fields[22] as int
       ..status = fields[23] as String
-      ..taetigkeiten = (fields[24] as List).cast<Taetigkeit>();
+      ..taetigkeiten = (fields[24] as List).cast<Taetigkeit>()
+      ..ausbildungen = (fields[25] as List).cast<Ausbildung>();
   }
 
   @override
   void write(BinaryWriter writer, Mitglied obj) {
     writer
-      ..writeByte(24)
+      ..writeByte(25)
       ..writeByte(0)
       ..write(obj.vorname)
       ..writeByte(1)
@@ -94,7 +95,9 @@ class MitgliedAdapter extends TypeAdapter<Mitglied> {
       ..writeByte(23)
       ..write(obj.status)
       ..writeByte(24)
-      ..write(obj.taetigkeiten);
+      ..write(obj.taetigkeiten)
+      ..writeByte(25)
+      ..write(obj.ausbildungen);
   }
 
   @override

--- a/lib/utilities/hive/mitglied.g.dart
+++ b/lib/utilities/hive/mitglied.g.dart
@@ -41,7 +41,8 @@ class MitgliedAdapter extends TypeAdapter<Mitglied> {
       ..beitragsartId = fields[22] as int
       ..status = fields[23] as String
       ..taetigkeiten = (fields[24] as List).cast<Taetigkeit>()
-      ..ausbildungen = (fields[25] as List).cast<Ausbildung>();
+      ..ausbildungen =
+          fields[25] == null ? [] : (fields[25] as List).cast<Ausbildung>();
   }
 
   @override

--- a/lib/utilities/nami/model/nami_member_ausbildung_model.dart
+++ b/lib/utilities/nami/model/nami_member_ausbildung_model.dart
@@ -10,7 +10,8 @@ class NamiMemberAusbildungModel {
 
   late String baustein;
 
-  late String? descriptor;
+  String? descriptor;
+
   NamiMemberAusbildungModel._({
     required this.id,
     required this.name,

--- a/lib/utilities/nami/model/nami_member_ausbildung_model.dart
+++ b/lib/utilities/nami/model/nami_member_ausbildung_model.dart
@@ -1,0 +1,31 @@
+// flutter packages pub run build_runner build
+class NamiMemberAusbildungModel {
+  late int id;
+
+  late DateTime datum;
+
+  late String veranstalter;
+
+  late String name;
+
+  late String baustein;
+
+  late String? descriptor;
+  NamiMemberAusbildungModel._({
+    required this.id,
+    required this.name,
+    required this.veranstalter,
+    required this.baustein,
+    required this.datum,
+  });
+  factory NamiMemberAusbildungModel.fromJson(Map<String, dynamic> json) {
+    String preText = 'entries_';
+    return NamiMemberAusbildungModel._(
+      baustein: json['${preText}baustein'],
+      veranstalter: json['${preText}veranstalter'],
+      id: json['${preText}id'],
+      datum: DateTime.tryParse(json['${preText}vstgTag']) ?? DateTime(0),
+      name: json['${preText}vstgName'],
+    );
+  }
+}

--- a/lib/utilities/nami/model/nami_member_ausbildung_model.dart
+++ b/lib/utilities/nami/model/nami_member_ausbildung_model.dart
@@ -10,8 +10,6 @@ class NamiMemberAusbildungModel {
 
   late String baustein;
 
-  String? descriptor;
-
   NamiMemberAusbildungModel._({
     required this.id,
     required this.name,

--- a/lib/utilities/nami/nami-member-fake.service.dart
+++ b/lib/utilities/nami/nami-member-fake.service.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:faker/faker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
+import 'package:nami/utilities/hive/ausbildung.dart';
 import 'package:nami/utilities/hive/mitglied.dart';
 import 'package:nami/utilities/hive/taetigkeit.dart';
 
@@ -54,14 +55,35 @@ Taetigkeit createTaetigkeit(
   return t;
 }
 
+Ausbildung createAusbildung({
+  required int id,
+  required DateTime datum,
+  required String name,
+  required String veranstalter,
+  required String baustein,
+}) {
+  final a = Ausbildung()
+    ..id = id
+    ..name = name
+    ..datum = datum
+    ..veranstalter = veranstalter
+    ..baustein = baustein;
+  return a;
+}
+
 /// first in taetigkeiten is the newest/current untergliederung
 Mitglied createMitgleid(
-    int id, DateTime start, DateTime birth, List<Taetigkeit> taetigkeiten,
-    {String? vorname,
-    String? nachname,
-    String? strasse,
-    String? ort,
-    String? plz}) {
+  int id,
+  DateTime start,
+  DateTime birth,
+  List<Taetigkeit> taetigkeiten, {
+  String? vorname,
+  String? nachname,
+  String? strasse,
+  String? ort,
+  String? plz,
+  List<Ausbildung> ausbildungen = const [],
+}) {
   var faker = Faker();
   var random = Random();
   return Mitglied()
@@ -88,7 +110,8 @@ Mitglied createMitgleid(
     ..landId = 1
     ..version = random.nextInt(60)
     ..lastUpdated = generateRandomDateDaysAgo(random.nextInt(30))
-    ..taetigkeiten = taetigkeiten;
+    ..taetigkeiten = taetigkeiten
+    ..ausbildungen = ausbildungen;
 }
 
 Mitglied createMemberDefaultPfadfinder(int age, int id) {
@@ -158,8 +181,28 @@ Mitglied createMemberDefaultLeiter(int age, String stufe, int id) {
   Taetigkeit taetigkeit = createTaetigkeit(
       int.parse('${id}1'), leiterStart, null, stufe,
       isLeader: true);
+  final ausbildung1 = createAusbildung(
+    id: int.parse('${id}01'),
+    name: "Bausteinwochenende 19.04.24-21.04.24",
+    datum: DateTime.parse("2024-04-19"),
+    baustein: "Baustein 2a",
+    veranstalter: "DPSG DV Köln",
+  );
+  final ausbildung2 = createAusbildung(
+    id: int.parse('${id}02'),
+    name: "Bausteinwochenende 19.04.24-21.04.24",
+    datum: DateTime.parse("2024-04-19"),
+    baustein: "Baustein 2b",
+    veranstalter: "DPSG DV Köln",
+  );
 
-  return createMitgleid(id, leiterStart, birthDate, [taetigkeit]);
+  return createMitgleid(
+    id,
+    leiterStart,
+    birthDate,
+    [taetigkeit],
+    ausbildungen: [ausbildung1, ausbildung2],
+  );
 }
 
 /// Leiter ist in allen Stufen Mitglied und Leiter gewesen

--- a/lib/utilities/nami/nami-member.service.dart
+++ b/lib/utilities/nami/nami-member.service.dart
@@ -125,16 +125,18 @@ Future<List<NamiMemberAusbildungModel>> _loadMemberAusbildungen(
     int id, String url, String path, String cookie) async {
   String fullUrl =
       '$url$path/mitglied-ausbildung/filtered-for-navigation/mitglied/mitglied/$id/flist';
-  sensLog.i('Request: Lade Ausbildungen eines Mitglieds');
+  sensLog.i('Request: Ausbildungen for ${sensId(id)}');
   final response =
       await http.get(Uri.parse(fullUrl), headers: {'Cookie': cookie});
-  final source = json.decode(const Utf8Decoder().convert(response.bodyBytes));
+  final source = json.decode(const Utf8Decoder()
+      .convert(response.bodyBytes)
+      .replaceAll("&#34;", '\\"'));
 
   if (response.statusCode == 200 && source['success']) {
     List<NamiMemberAusbildungModel> ausbildungen = [];
     for (Map<String, dynamic> item in source['data']) {
-      final taetigkeit = NamiMemberAusbildungModel.fromJson(item);
-      ausbildungen.add(taetigkeit);
+      final ausbildung = NamiMemberAusbildungModel.fromJson(item);
+      ausbildungen.add(ausbildung);
     }
     sensLog.i('Response: Loaded Ausbildungen for ${sensId(id)}');
     return ausbildungen;

--- a/lib/utilities/nami/nami-member.service.dart
+++ b/lib/utilities/nami/nami-member.service.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:nami/utilities/hive/ausbildung.dart';
 import 'package:nami/utilities/logger.dart';
+import 'package:nami/utilities/nami/model/nami_member_ausbildung_model.dart';
 import 'package:nami/utilities/nami/nami-member-fake.service.dart';
 import 'package:nami/utilities/nami/nami.service.dart';
 import 'package:nami/utilities/stufe.dart';
@@ -119,6 +121,29 @@ Future<List<NamiMemberTaetigkeitenModel>> _loadMemberTaetigkeiten(
   }
 }
 
+Future<List<NamiMemberAusbildungModel>> _loadMemberAusbildungen(
+    int id, String url, String path, String cookie) async {
+  String fullUrl =
+      '$url$path/mitglied-ausbildung/filtered-for-navigation/mitglied/mitglied/$id/flist';
+  sensLog.i('Request: Lade Ausbildungen eines Mitglieds');
+  final response =
+      await http.get(Uri.parse(fullUrl), headers: {'Cookie': cookie});
+  final source = json.decode(const Utf8Decoder().convert(response.bodyBytes));
+
+  if (response.statusCode == 200 && source['success']) {
+    List<NamiMemberAusbildungModel> ausbildungen = [];
+    for (Map<String, dynamic> item in source['data']) {
+      final taetigkeit = NamiMemberAusbildungModel.fromJson(item);
+      ausbildungen.add(taetigkeit);
+    }
+    sensLog.i('Response: Loaded Ausbildungen for ${sensId(id)}');
+    return ausbildungen;
+  } else {
+    sensLog.e('Failed to load Ausbildungen for ${sensId(id)}');
+    return [];
+  }
+}
+
 // ignore: unused_element
 Future<NamiMemberTaetigkeitenModel?> _loadMemberTaetigkeit(int memberId,
     int taetigkeitId, String url, String path, String cookie) async {
@@ -203,6 +228,7 @@ Future<void> _storeMitgliedToHive(
     double progressStep) async {
   NamiMemberDetailsModel rawMember;
   List<NamiMemberTaetigkeitenModel> rawTaetigkeiten;
+  List<NamiMemberAusbildungModel> rawAusbildungen;
   try {
     rawMember =
         await _loadMemberDetails(mitgliedId, url, path, gruppierung, cookie);
@@ -220,6 +246,14 @@ Future<void> _storeMitgliedToHive(
     rawTaetigkeiten = [];
   }
 
+  try {
+    rawAusbildungen =
+        await _loadMemberAusbildungen(mitgliedId, url, path, cookie);
+  } catch (e, st) {
+    sensLog.e('Failed to load member ausbildungen ${sensId(mitgliedId)}',
+        error: e, stackTrace: st);
+    rawAusbildungen = [];
+  }
   List<Taetigkeit> taetigkeiten = [];
   for (NamiMemberTaetigkeitenModel item in rawTaetigkeiten) {
     taetigkeiten.add(Taetigkeit()
@@ -233,6 +267,18 @@ Future<void> _storeMitgliedToHive(
       ..gruppierung = item.gruppierung
       ..berechtigteGruppe = item.berechtigteGruppe
       ..berechtigteUntergruppen = item.berechtigteUntergruppen);
+  }
+
+  List<Ausbildung> ausbildungen = [];
+  for (final item in rawAusbildungen) {
+    ausbildungen.add(
+      Ausbildung()
+        ..id = item.id
+        ..name = item.name
+        ..veranstalter = item.veranstalter
+        ..datum = item.datum
+        ..baustein = item.baustein,
+    );
   }
 
   Mitglied mitglied = Mitglied()
@@ -261,7 +307,8 @@ Future<void> _storeMitgliedToHive(
     ..mglTypeId = rawMember.mglTypeId
     ..beitragsartId = rawMember.beitragsartId ?? 0
     ..status = rawMember.status
-    ..taetigkeiten = taetigkeiten;
+    ..taetigkeiten = taetigkeiten
+    ..ausbildungen = ausbildungen;
 
   memberBox.put(mitgliedId, mitglied);
   memberAllProgressNotifier.value += progressStep;

--- a/lib/utilities/nami/nami.service.dart
+++ b/lib/utilities/nami/nami.service.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'package:html/dom.dart';
 import 'package:html/parser.dart';
 import 'package:http/http.dart' as http;
-import 'package:nami/utilities/hive/ausbildung.dart';
 import 'package:nami/utilities/hive/settings.dart';
 import 'package:nami/utilities/logger.dart';
 import 'package:nami/utilities/nami/nami-login.service.dart';

--- a/lib/utilities/nami/nami.service.dart
+++ b/lib/utilities/nami/nami.service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:html/dom.dart';
 import 'package:html/parser.dart';
 import 'package:http/http.dart' as http;
+import 'package:nami/utilities/hive/ausbildung.dart';
 import 'package:nami/utilities/hive/settings.dart';
 import 'package:nami/utilities/logger.dart';
 import 'package:nami/utilities/nami/nami-login.service.dart';

--- a/lib/utilities/nami/nami_rechte.dart
+++ b/lib/utilities/nami/nami_rechte.dart
@@ -14,7 +14,11 @@ enum AllowedFeatures {
   memberEdit,
   memberCreate,
   stufenwechsel,
-  fuehrungszeugnis
+  fuehrungszeugnis,
+  ausbildungCreate,
+  ausbildungEdit,
+  ausbildungRead,
+  ausbildungDelete,
 }
 
 extension AllowedFeaturesExtension on AllowedFeatures {
@@ -32,8 +36,14 @@ extension AllowedFeaturesExtension on AllowedFeatures {
         return 'Stufenwechsel';
       case AllowedFeatures.fuehrungszeugnis:
         return 'Führungszeugnis';
-      default:
-        return 'Unknown';
+      case AllowedFeatures.ausbildungCreate:
+        return 'Ausbildung anlegen';
+      case AllowedFeatures.ausbildungEdit:
+        return 'Ausbildung bearbeiten';
+      case AllowedFeatures.ausbildungRead:
+        return 'Ausbildung anzeigen';
+      case AllowedFeatures.ausbildungDelete:
+        return 'Ausbildung löschen';
     }
   }
 }
@@ -77,6 +87,18 @@ Future<List<AllowedFeatures>> getRechte() async {
   }
   if (rechte.containsKey(473) && rechte.containsKey(474)) {
     allowedFeatures.add(AllowedFeatures.fuehrungszeugnis);
+  }
+  if (rechte.containsKey(192)) {
+    allowedFeatures.add(AllowedFeatures.ausbildungCreate);
+  }
+  if (rechte.containsKey(193)) {
+    allowedFeatures.add(AllowedFeatures.ausbildungRead);
+  }
+  if (rechte.containsKey(194)) {
+    allowedFeatures.add(AllowedFeatures.ausbildungEdit);
+  }
+  if (rechte.containsKey(195)) {
+    allowedFeatures.add(AllowedFeatures.ausbildungDelete);
   }
 
   sensLog.t('Rechte: ${allowedFeatures.map((e) => e.toReadableString())}');


### PR DESCRIPTION
Für alle Mitglieder werden nun neben den Tätigkeiten auch die Ausbildungen geladen. Dieser werden bisher nur, wenn vorhanden, auf der Mitglied Details Seite angezeigt als neuer Tab. Das Laden der Daten dauert nun ein bisschen länger, aber das geschieht da ja nicht so oft. Müsste also okay sein.
Man könnte auch argumentieren, dass diese Ausbildungsdaten nicht offline gespeichert werden müssen, sondern stattdessen geladen werden, wenn man die Detailsseite öffnet. Das Problem ist aber, dass dann der Ausbildungstab immer angezeigt werden müsste. Außerdem macht das die Implementierung ein bisschen komplizierter. 