### PR TITLE
refactor: load and store rechte before syncing all members

### DIFF
--- a/lib/screens/profil/profil.dart
+++ b/lib/screens/profil/profil.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:nami/utilities/nami/nami_rechte.dart';
 
 class Profil extends StatefulWidget {
   const Profil({Key? key}) : super(key: key);
@@ -14,8 +15,24 @@ class _ProfilState extends State<Profil> {
       appBar: AppBar(
         title: const Center(child: Text('Profil')),
       ),
-      body: const Center(
-        child: Text('Profil'),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text("Deine Rechte:", style: Theme.of(context).textTheme.titleMedium),
+          Card(
+            margin: EdgeInsets.zero,
+            child: Column(
+              children: [
+                for (final feature in getAllowedFeatures())
+                  ListTile(
+                    title: Text(
+                      feature.toReadableString(),
+                    ),
+                  )
+              ],
+            ),
+          )
+        ],
       ),
     );
   }

--- a/lib/utilities/app.state.dart
+++ b/lib/utilities/app.state.dart
@@ -167,12 +167,12 @@ class AppStateHandler extends ChangeNotifier {
         await reloadMetadataFromServer();
         metaProgressNotifier.value = true;
       }
-      await syncMember(
+      await syncMembers(
         memberAllProgressNotifier,
         memberOverviewProgressNotifier,
+        rechteProgressNotifier,
         forceUpdate: loadAll,
       );
-      rechteProgressNotifier.value = await getRechte();
       syncState = SyncState.successful;
       if (background) {
         sensLog.i('sync successful in background');

--- a/lib/utilities/hive/hive.handler.dart
+++ b/lib/utilities/hive/hive.handler.dart
@@ -15,6 +15,7 @@ void logout() {
   Hive.box<Mitglied>('members').clear();
   deleteGruppierungId();
   deleteGruppierungName();
+  setRechte([]);
 
   setStammheim('');
   setFavouriteList([]);

--- a/lib/utilities/hive/settings.dart
+++ b/lib/utilities/hive/settings.dart
@@ -28,6 +28,7 @@ enum SettingValue {
   metaStaatsangehoerigkeitOptions,
   metaMitgliedstypOptions,
   biometricAuthenticationEnabled,
+  rechte,
 }
 
 void setMetaData(
@@ -125,6 +126,10 @@ bool getBiometricAuthenticationEnabled() {
   return Hive.box('settingsBox')
           .get(SettingValue.biometricAuthenticationEnabled.toString()) ??
       false;
+}
+
+List<int> getRechte() {
+  return Hive.box('settingsBox').get(SettingValue.rechte.toString()) ?? [];
 }
 
 int addFavouriteList(int id) {
@@ -236,6 +241,10 @@ void setDataLoadingOverWifiOnly(bool value) {
 void setBiometricAuthenticationEnabled(bool value) {
   Hive.box('settingsBox')
       .put(SettingValue.biometricAuthenticationEnabled.toString(), value);
+}
+
+void setRechte(List<int> rechte) {
+  Hive.box('settingsBox').put(SettingValue.rechte.toString(), rechte);
 }
 
 String getNamiApiCookie() {

--- a/lib/utilities/nami/nami-member.service.dart
+++ b/lib/utilities/nami/nami-member.service.dart
@@ -20,8 +20,6 @@ import 'package:nami/utilities/hive/taetigkeit.dart';
 import 'model/nami_member_details.model.dart';
 import 'model/nami_taetigkeiten.model.dart';
 
-ScaffoldFeatureController<SnackBar, SnackBarClosedReason>? snackbar;
-
 int _getVersionOfMember(int id, List<Mitglied> mitglieder) {
   try {
     Mitglied mitglied = mitglieder.firstWhere((m) => m.id == id);
@@ -184,6 +182,9 @@ Future<void> syncMembers(
   if (cookie == 'testLoginCookie') {
     await storeFakeSetOfMemberInHive(
         memberBox, memberOverviewProgressNotifier, memberAllProgressNotifier);
+    setRechte(await loadRechte());
+    rechteProgressNotifier.value = getAllowedFeatures();
+
     setLastNamiSync(DateTime.now());
     return;
   }

--- a/lib/utilities/nami/nami-member.service.dart
+++ b/lib/utilities/nami/nami-member.service.dart
@@ -272,7 +272,8 @@ Future<Mitglied?> _storeMitgliedToHive(
   }
 
   final allowedFeatures = getAllowedFeatures();
-  if (allowedFeatures.contains(AllowedFeatures.ausbildungRead)) {
+  if (allowedFeatures.contains(AllowedFeatures.ausbildungRead) ||
+      mitgliedId == getNamiLoginId()) {
     try {
       rawAusbildungen =
           await _loadMemberAusbildungen(mitgliedId, url, path, cookie);

--- a/lib/utilities/nami/nami-member.service.dart
+++ b/lib/utilities/nami/nami-member.service.dart
@@ -6,6 +6,7 @@ import 'package:nami/utilities/logger.dart';
 import 'package:nami/utilities/nami/model/nami_member_ausbildung_model.dart';
 import 'package:nami/utilities/nami/nami-member-fake.service.dart';
 import 'package:nami/utilities/nami/nami.service.dart';
+import 'package:nami/utilities/nami/nami_rechte.dart';
 import 'package:nami/utilities/stufe.dart';
 import 'package:nami/utilities/hive/mitglied.dart';
 import 'package:hive/hive.dart';
@@ -166,9 +167,10 @@ Future<NamiMemberTaetigkeitenModel?> _loadMemberTaetigkeit(int memberId,
   }
 }
 
-Future<void> syncMember(
+Future<void> syncMembers(
   ValueNotifier<double> memberAllProgressNotifier,
-  ValueNotifier<bool?> memberOverviewProgressNotifier, {
+  ValueNotifier<bool?> memberOverviewProgressNotifier,
+  ValueNotifier<List<AllowedFeatures>> rechteProgressNotifier, {
   bool forceUpdate = false,
 }) async {
   setLastNamiSyncTry(DateTime.now());
@@ -200,18 +202,38 @@ Future<void> syncMember(
 
   memberOverviewProgressNotifier.value = true;
   sensLog.i('Starte Syncronisation der Mitgliedsdetails');
-  var futures = <Future>[];
-
-  for (var mitgliedId in mitgliedIds) {
-    futures.add(_storeMitgliedToHive(
-        mitgliedId,
+  final futures = <Future>[];
+  final userMitgliedId = getNamiLoginId()!;
+  if (mitgliedIds.contains(userMitgliedId)) {
+    final userMitgliedDetails = await _storeMitgliedToHive(
+        userMitgliedId,
         memberBox,
         url,
         path,
         gruppierung,
         cookie,
         memberAllProgressNotifier,
-        1 / mitgliedIds.length));
+        1 / mitgliedIds.length);
+    if (userMitgliedDetails == null) {
+      throw Exception('Failed to load details of current user');
+    }
+  }
+  final rechte = await loadRechte();
+  setRechte(rechte);
+  rechteProgressNotifier.value = getAllowedFeatures();
+
+  for (var mitgliedId in mitgliedIds) {
+    if (mitgliedId == userMitgliedId) continue;
+    futures.add(_storeMitgliedToHive(
+      mitgliedId,
+      memberBox,
+      url,
+      path,
+      gruppierung,
+      cookie,
+      memberAllProgressNotifier,
+      1 / mitgliedIds.length,
+    ));
   }
   await Future.wait(futures);
   memberAllProgressNotifier.value = 1.0;
@@ -219,7 +241,7 @@ Future<void> syncMember(
   sensLog.i('Syncronisation der Mitgliedsdetails abgeschlossen');
 }
 
-Future<void> _storeMitgliedToHive(
+Future<Mitglied?> _storeMitgliedToHive(
     int mitgliedId,
     Box<Mitglied> memberBox,
     String url,
@@ -230,14 +252,14 @@ Future<void> _storeMitgliedToHive(
     double progressStep) async {
   NamiMemberDetailsModel rawMember;
   List<NamiMemberTaetigkeitenModel> rawTaetigkeiten;
-  List<NamiMemberAusbildungModel> rawAusbildungen;
+  List<NamiMemberAusbildungModel> rawAusbildungen = [];
   try {
     rawMember =
         await _loadMemberDetails(mitgliedId, url, path, gruppierung, cookie);
   } catch (e, st) {
     sensLog.e('Failed to load member ${sensId(mitgliedId)}',
         error: e, stackTrace: st);
-    return;
+    return null;
   }
   try {
     rawTaetigkeiten =
@@ -248,13 +270,15 @@ Future<void> _storeMitgliedToHive(
     rawTaetigkeiten = [];
   }
 
-  try {
-    rawAusbildungen =
-        await _loadMemberAusbildungen(mitgliedId, url, path, cookie);
-  } catch (e, st) {
-    sensLog.e('Failed to load member ausbildungen ${sensId(mitgliedId)}',
-        error: e, stackTrace: st);
-    rawAusbildungen = [];
+  final allowedFeatures = getAllowedFeatures();
+  if (allowedFeatures.contains(AllowedFeatures.ausbildungRead)) {
+    try {
+      rawAusbildungen =
+          await _loadMemberAusbildungen(mitgliedId, url, path, cookie);
+    } catch (e, st) {
+      sensLog.e('Failed to load member ausbildungen ${sensId(mitgliedId)}',
+          error: e, stackTrace: st);
+    }
   }
   List<Taetigkeit> taetigkeiten = [];
   for (NamiMemberTaetigkeitenModel item in rawTaetigkeiten) {
@@ -314,4 +338,5 @@ Future<void> _storeMitgliedToHive(
 
   memberBox.put(mitgliedId, mitglied);
   memberAllProgressNotifier.value += progressStep;
+  return mitglied;
 }

--- a/lib/utilities/nami/nami_rechte.dart
+++ b/lib/utilities/nami/nami_rechte.dart
@@ -52,7 +52,7 @@ Future<List<int>> loadRechte() async {
   sensLog.i('Rechte werden geladen');
   final cookie = getNamiApiCookie();
   if (cookie == 'testLoginCookie') {
-    return [5, 36, 58, 118, 139, 314];
+    return [5, 36, 58, 118, 139, 314, 193, 194, 195];
   }
   Map<int, String> rechte;
   try {

--- a/lib/utilities/nami/nami_rechte.dart
+++ b/lib/utilities/nami/nami_rechte.dart
@@ -48,56 +48,63 @@ extension AllowedFeaturesExtension on AllowedFeatures {
   }
 }
 
-/// Dokumentation zu den Rechten finden sich im README.md
-/// Rechte werden anhand der User ID geladen (nicht die Mitgliedsnummer)
-Future<List<AllowedFeatures>> getRechte() async {
-  sensLog.w('Rechte werden geladen');
+Future<List<int>> loadRechte() async {
+  sensLog.i('Rechte werden geladen');
   final cookie = getNamiApiCookie();
   if (cookie == 'testLoginCookie') {
-    return [AllowedFeatures.appStart];
+    return [5, 36, 58, 118, 139, 314];
   }
-  List<AllowedFeatures> allowedFeatures = [];
   Map<int, String> rechte;
   try {
     rechte = await _loadRechteJson();
-  } catch (e) {
-    sensLog.i('Failed to load rechte: $e');
+  } catch (e, st) {
+    sensLog.e('Failed to load rechte', error: e, stackTrace: st);
+    return [];
+  }
+  return rechte.keys.toList();
+}
+
+/// Dokumentation zu den Rechten finden sich im README.md
+/// Rechte werden anhand der User ID geladen (nicht die Mitgliedsnummer)
+List<AllowedFeatures> getAllowedFeatures() {
+  final rechte = getRechte();
+  if (rechte.isEmpty) {
     return [AllowedFeatures.error];
   }
-
-  if (rechte.containsKey(5) &&
-      rechte.containsKey(36) &&
-      rechte.containsKey(58) &&
-      rechte.containsKey(118) &&
-      rechte.containsKey(139) &&
-      rechte.containsKey(314)) {
+  List<AllowedFeatures> allowedFeatures = [];
+  if (rechte.contains(5) &&
+      rechte.contains(36) &&
+      rechte.contains(58) &&
+      rechte.contains(118) &&
+      rechte.contains(139) &&
+      rechte.contains(314)) {
     allowedFeatures.add(AllowedFeatures.appStart);
   }
-  if (rechte.containsKey(57) && rechte.containsKey(59)) {
+  if (rechte.contains(57) && rechte.contains(59)) {
     allowedFeatures.add(AllowedFeatures.stufenwechsel);
   }
-  if (rechte.containsKey(4) && rechte.containsKey(57)) {
+  if (rechte.contains(4) && rechte.contains(57)) {
     allowedFeatures.add(AllowedFeatures.memberEdit);
   }
-  if (rechte.containsKey(6) &&
-      rechte.containsKey(59) &&
-      rechte.containsKey(313) &&
-      rechte.containsKey(316)) {
+  if (rechte.contains(6) &&
+      rechte.contains(59) &&
+      rechte.contains(313) &&
+      rechte.contains(316)) {
     allowedFeatures.add(AllowedFeatures.memberCreate);
   }
-  if (rechte.containsKey(473) && rechte.containsKey(474)) {
+  if (rechte.contains(473) && rechte.contains(474)) {
     allowedFeatures.add(AllowedFeatures.fuehrungszeugnis);
   }
-  if (rechte.containsKey(192)) {
+  if (rechte.contains(192)) {
     allowedFeatures.add(AllowedFeatures.ausbildungCreate);
   }
-  if (rechte.containsKey(193)) {
+  if (rechte.contains(193)) {
     allowedFeatures.add(AllowedFeatures.ausbildungRead);
   }
-  if (rechte.containsKey(194)) {
+  if (rechte.contains(194)) {
     allowedFeatures.add(AllowedFeatures.ausbildungEdit);
   }
-  if (rechte.containsKey(195)) {
+  if (rechte.contains(195)) {
     allowedFeatures.add(AllowedFeatures.ausbildungDelete);
   }
 


### PR DESCRIPTION
Nun wird beim sync zuerst die eigenen Mitgliedsdaten geladen, um anschließend die Rechte zu laden. Erst dann werden die anderen Mitglieder geladen. Das hat den Vorteil, dass ich die Ausbildungen nur laden kann, wenn die entsprechenden Rechte auch vorhanden sind.

close #101 