### PR TITLE
fix: show details page for leiter

### DIFF
--- a/lib/screens/mitgliedsliste/mitglied_details.dart
+++ b/lib/screens/mitgliedsliste/mitglied_details.dart
@@ -916,7 +916,7 @@ class MitgliedDetailState extends State<MitgliedDetail>
         minStufenWechselJahr.isBefore(nextStufenwechselDatum);
     Stufe? nextStufe = widget.mitglied.nextStufe;
     bool nextStufeAlreadyAssigned = widget.mitglied.taetigkeiten
-        .any((element) => element.untergliederung == nextStufe!.display);
+        .any((element) => element.untergliederung == nextStufe?.display);
 
     // check if stufenwechsel is possible
     if (nextStufeAlreadyAssigned ||

--- a/lib/utilities/nami/nami.service.dart
+++ b/lib/utilities/nami/nami.service.dart
@@ -24,7 +24,7 @@ dynamic withMaybeRetry(Future<http.Response> Function() func,
   final response = await func();
 
   if (response.statusCode == 200 && jsonDecode(response.body)['success']) {
-    return jsonDecode(response.body);
+    return jsonDecode(utf8.decode(response.bodyBytes));
   } else if (response.statusCode == 500 ||
       (response.statusCode == 200 &&
           jsonDecode(response.body)["message"] == "Session expired")) {

--- a/lib/utilities/nami/nami_member_add_meta.dart
+++ b/lib/utilities/nami/nami_member_add_meta.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:http/http.dart' as http;
 import 'package:nami/utilities/app.state.dart';
 import 'package:nami/utilities/hive/settings.dart';
@@ -12,13 +10,12 @@ Future<Map<String, String>> getMetadata(String url) async {
   return withMaybeRetry(
     () async => await http.get(Uri.parse(url), headers: {
       'Cookie': getNamiApiCookie(),
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json; charset=UTF-8',
     }),
     'Failed to load metadata: $url',
   ).then<Map<String, String>>((body) {
     Map<String, String> map = {
-      for (var m in body['data'])
-        m['id'].toString(): utf8.decode(m['descriptor'].codeUnits)
+      for (var m in body['data']) m['id'].toString(): m['descriptor']
     };
 
     // Sortieren der Map nach den Schlüsseln (descriptor)

--- a/lib/utilities/nami/nami_member_add_meta.dart
+++ b/lib/utilities/nami/nami_member_add_meta.dart
@@ -10,7 +10,7 @@ Future<Map<String, String>> getMetadata(String url) async {
   return withMaybeRetry(
     () async => await http.get(Uri.parse(url), headers: {
       'Cookie': getNamiApiCookie(),
-      'Content-Type': 'application/json; charset=UTF-8',
+      'Content-Type': 'application/json'
     }),
     'Failed to load metadata: $url',
   ).then<Map<String, String>>((body) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   fl_chart: ^0.70.2
   latlong2: ^0.9.0
   intl: any
-  flutter_form_builder: ^9.1.1
+  flutter_form_builder: ^10.0.1
   form_builder_validators: ^11.0.0
   html: ^0.15.4
   wiredash: ^2.2.0


### PR DESCRIPTION
Meine letzte Contribution ist erstaunlich lange her, aber in den letzten Wochen hat mich ein Problem genervt, dass ich jetzt noch nochmal versucht habe, alles zum Laufen zu bekommen.
Wenn man die MitgliedDetail Seite von einem Leiter öffnet, ist diese grau, da es für einen Leiter keine nächste Stufe gibt.

Außerdem habe ich die packages upgraded und ein Problem beim holen der metadata gehabt. Durch http 1.4.0 https://pub.dev/packages/http/changelog#140 wird nun utf-8 statt latin-1 encoding für application/json genutzt. Dadurch funktionierte das manuelle utf-8 decoding nicht mehr. Um das für neue und alte http Versionen zu fixen, wird der body nun immer explizit komplett mit utf-8 decoded. Das müsste es fixen.